### PR TITLE
suppressions: 2026-09-06 scan

### DIFF
--- a/auditor/logs/events.jsonl
+++ b/auditor/logs/events.jsonl
@@ -4162,3 +4162,5 @@
 {"timestamp":"2026-09-05T20:23:33Z","workflow":"track","event":"status_check","run_id":"33989379353","run_number":842,"data":{"contributed":50,"tracked":40,"case_study_ready":43,"rule_adopted":1}}
 {"timestamp":"2026-09-05T22:04:56Z","workflow":"daily-report","event":"report_generated","run_id":"33994864531","run_number":155,"data":{"total_repos":294}}
 {"timestamp":"2026-09-05T22:31:58Z","workflow":"dashboard","event":"dashboard_rendered","run_id":"33996170202","run_number":111,"data":{"repos":294,"findings":5338,"advisories":22}}
+{"timestamp":"2026-09-06T00:08:47Z","workflow":"suppressions","event":"search_failed","run_id":"34000512064","run_number":20,"data":{"reason":"gh api search returned non-zero — partial or empty results"}}
+{"timestamp":"2026-09-06T00:08:47Z","workflow":"suppressions","event":"scan_complete","run_id":"34000512064","run_number":20,"data":{"candidates":0,"emitted":0,"skipped_self":0,"skipped_dup":0,"skipped_no_overrides":0,"search_ok":false}}


### PR DESCRIPTION
Automated bot commit from `Downstream Suppressions Scan` ([run 34000512064](https://github.com/xiaolai/nlpm/actions/runs/34000512064)).

Merged via the auditor PR-flow (see `auditor/scripts/commit-via-pr.sh`).