### PR TITLE
ci(site): drop Cloudflare purge, unblocking the deploy workflow

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -10,6 +10,13 @@ name: Deploy nlpm.com
 #   - daily 23:00 UTC, after auditor-render-dashboard at 22:30 — so the
 #     dashboard's freshly-rendered cross-repo aggregate makes it onto
 #     the site without manual intervention.
+#
+# No Cloudflare purge step: nlpm.com is served directly by GitHub Pages
+# on a DNS-only record, with no CF proxy in front. Proxying it broke
+# GitHub's Let's Encrypt renewal — CF intercepted the ACME HTTP-01
+# challenge, the cert expired 2026-08-17, and CF Full (Strict) then
+# returned 526 to every visitor. Do not re-add the proxy or a purge
+# step without re-checking that interaction first.
 
 on:
   push:
@@ -127,34 +134,3 @@ jobs:
           # Deploys are inferred from gh-pages commits; we deliberately do
           # not append to auditor/logs/events.jsonl on main, since that
           # would push deploy churn into the auditor's append-only log.
-
-      - name: Wait for GitHub Pages CDN to propagate
-        # Pushing to gh-pages doesn't instantly update what GitHub Pages
-        # serves at its edge — there's typically a 30–60s lag. Purging
-        # CF before that lag elapses just re-caches the OLD content from
-        # GitHub's edge. Wait first, then purge.
-        run: sleep 75
-
-      - name: Purge Cloudflare cache
-        # Two failure modes a deploy can leave behind without this:
-        #   - stale negative 404s for URLs that didn't exist on the prior
-        #     deploy (CF caches 404s up to ~10 min)
-        #   - stale content for URLs that existed but changed
-        # Both clear with a zone-wide purge_everything. Step gated on the
-        # three secrets so the workflow stays functional on forks.
-        env:
-          CF_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
-          CF_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
-          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-        run: |
-          if [ -z "$CF_API_KEY" ] || [ -z "$CF_EMAIL" ] || [ -z "$CF_ZONE_ID" ]; then
-            echo "Cloudflare secrets not configured — skipping purge."
-            exit 0
-          fi
-          RESP=$(curl -fsS -X POST \
-            -H "X-Auth-Key: $CF_API_KEY" \
-            -H "X-Auth-Email: $CF_EMAIL" \
-            -H "Content-Type: application/json" \
-            "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/purge_cache" \
-            --data '{"purge_everything":true}')
-          echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print('cf-purge success=' + str(d.get('success')))"


### PR DESCRIPTION
## Why

`deploy-site` has failed on all five most recent runs. Build and deploy succeed every time; the only failing step is **Purge Cloudflare cache**, which gets HTTP 401 because the Cloudflare API credentials went stale. That is why the site content stayed current while the workflow stayed red.

## What this changes

Removes the purge step, and the 75-second CDN wait that existed only to sequence before it. The wait's own comment said its sole purpose was to stop the purge re-caching stale content, so with the purge gone it is dead time on every deploy.

Adds a header note recording why there is no purge, so the proxy and the purge do not get quietly re-introduced together later.

## Context: this is half of the nlpm.com outage fix

The site has been returning **526** to every visitor for roughly three weeks. The cause is the Cloudflare proxy, not the build:

| Check | Result |
|---|---|
| DNS for nlpm.com | `104.21.78.50`, `172.67.216.239`, both Cloudflare proxy IPs |
| HTTPS response | `526` invalid origin certificate |
| GitHub cert state | `bad_authz`, ACME authorization needs restarting |
| Last cert expiry | 2026-08-17 |
| ACME challenge path | Cloudflare 404, never reaches GitHub |
| gh-pages last deploy | 2026-09-08, content current |

Cloudflare intercepts `/.well-known/acme-challenge/`, so GitHub's Let's Encrypt renewal cannot complete. The certificate expired on 2026-08-17 and Cloudflare Full (Strict) has rejected the origin ever since.

The remaining half is a DNS change: point nlpm.com at GitHub's four Pages addresses as a DNS-only record, then restart the ACME authorization and enable Enforce HTTPS. Once that lands, Cloudflare is out of the serving path entirely and this purge step would have nothing to purge.

Merging this is safe independently. The step it removes has been a no-op since the credentials expired.
